### PR TITLE
Update trigger paths in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
       - 'levoai/**'
       - '!levoai/levoai-satellite/**'
       - '!levoai/levoai-ebpf-sensor/**'
+      - '!levoai/levoai-pcap-sensor/**'
   workflow_dispatch:
 
 # Make sure there is only one instance of this workflow running at any time so that we don't override charts


### PR DESCRIPTION
We don't want it to run for the 'levoai-pcap-sensor' chart.