### PR TITLE
fix: correct chart name in release-sidecar-injector workflow

### DIFF
--- a/.github/workflows/release-sidecar-injector.yaml
+++ b/.github/workflows/release-sidecar-injector.yaml
@@ -12,6 +12,6 @@ jobs:
   release:
     uses: ./.github/workflows/release-private-chart.yaml
     with:
-      name: aigateway-sidecar-injector
+      name: levoai-sidecar-injector
       version: ${{ inputs.version }}
     secrets: inherit


### PR DESCRIPTION
## Summary

The `release-sidecar-injector.yaml` workflow was referencing the chart as `aigateway-sidecar-injector`, but the chart's `Chart.yaml` defines `name: levoai-sidecar-injector`. When the aigateway release pipeline packages and pushes the chart to `gs://levoai-private-helm-charts`, it creates `levoai-sidecar-injector-{version}.tgz`. The workflow's `helm pull levoai-private/aigateway-sidecar-injector` would fail to find it.

This fixes the name to `levoai-sidecar-injector`, consistent with the `levoai-*` naming convention used by all other charts in this repo (`levoai-aigateway`, `levoai-satellite`, `levoai-ebpf-sensor`, etc.).

## Test plan

- [ ] Trigger `release-sidecar-injector.yaml` with a known version after the aigateway release pipeline has pushed the chart to GCS
- [ ] Verify the chart appears in the `levoai/` directory and is published to `charts.levo.ai`