### PR TITLE
CU-86ba9pz96 Skip all workflows on draft PRs

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,6 +1,7 @@
 name: Semgrep
 on:
-  pull_request: {}
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches:
       - main
@@ -17,7 +18,7 @@ jobs:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}
     container:
       image: returntocorp/semgrep
-    if: (github.actor != 'dependabot[bot]')
+    if: (github.actor != 'dependabot[bot]') && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     steps:
       - uses: actions/checkout@v3
       - run: semgrep ci


### PR DESCRIPTION
## Summary
- Skip all CI workflows on draft PRs to save runner resources.
- Add `ready_for_review` to `pull_request` triggers so workflows fire when a draft is marked as ready.
- Add `if: github.event.pull_request.draft == false` (or the multi-trigger variant) on every job that could fire from a PR event.

## Workflows updated
- `semgrep.yml` — added `types: [opened, synchronize, reopened, ready_for_review]` to `pull_request`; extended existing job-level `if:` with the multi-trigger draft-skip guard.

## Test plan
- [ ] Open a draft PR — no workflows run.
- [ ] Push to the draft PR — still skipped.
- [ ] Mark "Ready for review" — workflows trigger.
- [ ] Non-PR triggers still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)